### PR TITLE
Added translation of Symbol

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: crinja
 version: 0.3.0
 license: Apache-2.0
-crystal: 0.24.1
+crystal: 0.25.0
 
 authors:
   - Johannes Müller <straightshoota@gmail.com>

--- a/src/runtime/value.cr
+++ b/src/runtime/value.cr
@@ -76,6 +76,8 @@ class Crinja
       Value.new value
     when Iterator
       Value.new Value::Iterator.new(value)
+    when Symbol
+      Value.new value.to_s
     when Char
       Value.new value.to_s
     when Value

--- a/src/util/scope_map.cr
+++ b/src/util/scope_map.cr
@@ -8,7 +8,7 @@ class Crinja::Util::ScopeMap(K, V)
     merge!(scope) unless scope.nil?
   end
 
-  delegate :[]=, :delete, :clear, :merge!, to: scope
+  delegate :delete, :clear, :merge!, to: scope
 
   def size
     keys.size
@@ -34,6 +34,10 @@ class Crinja::Util::ScopeMap(K, V)
     end
 
     parent.try(&.[key]) || undefined
+  end
+
+  def []=(key : K, value : V)
+    scope[key] = value
   end
 
   def undefined


### PR DESCRIPTION
Was getting the following error when using symbols for keys in my data hash:

```
Exception: type error: can't wrap Symbol in Crinja::Value (Exception)
  from lib/crinja/src/runtime/value.cr:89:7 in 'value'
  from lib/crinja/src/runtime/value.cr:111:5 in 'new'
  from lib/crinja/src/runtime/value.cr:29:14 in 'dictionary'
  from lib/crinja/src/runtime/value.cr:58:7 in 'value'
  from lib/crinja/src/runtime/value.cr:111:5 in 'new'
  from lib/crinja/src/runtime/value.cr:48:29 in 'variables'
  from lib/crinja/src/runtime/context.cr:78:5 in 'merge!'
```

Adding translation of symbol to string seems to have solved this issue.