### PR TITLE
Remove getitem

### DIFF
--- a/playground/objects.md
+++ b/playground/objects.md
@@ -6,11 +6,10 @@ To make custom objects usable in Crinja, they need to include `Crinja::PyObject`
 
 Classes *may* implement the following methods to make properties accessbile:
 
-1. `#getattr(name : Crinja::Value)`: Access an attribute (e.g. an instance property) of this class.
-2. `#__getitem__(name : Crinja::Value)`: Access an item (e.g. an array member) of this class.
-3. `#__call__(name : String) : Crinja::Callable | Callable::Proc`: Expose a callable as method of this class.
+* `#getattr(name : Crinja::Value)`: Access an attribute (e.g. an instance property) of this class.
+* `#__call__(name : String) : Crinja::Callable | Callable::Proc`: Expose a callable as method of this class.
 
-They *must* return an `Undefined` if there is no attribute or item of that name.
+`getattr` must return an `Undefined` if there is no attribute of that name.
 
 ```playground
 require "./crinja"

--- a/spec/util/pyobject_spec.cr
+++ b/spec/util/pyobject_spec.cr
@@ -20,7 +20,12 @@ private class User
     when "age"
       age.days / 365
     else
-      Crinja::Undefined.new(attr.to_s)
+      raw = attr.raw
+      if raw.responds_to?(:to_i)
+        @name[raw.to_i].to_s
+      else
+        Crinja::Undefined.new(attr.to_s)
+      end
     end
   end
 
@@ -31,19 +36,10 @@ private class User
       end
     end
   end
-
-  def __getitem__(attr : Crinja::Value)
-    raw = attr.raw
-    if raw.responds_to?(:to_i)
-      @name[raw.to_i].to_s
-    else
-      Crinja::Undefined.new(attr.to_s)
-    end
-  end
 end
 
 describe Crinja::PyObject do
-  it "resolves __getitem__" do
+  it "resolves dynamic attribute" do
     user = User.new("Tom", Time.utc(1974, 3, 28))
     evaluate_expression_raw(%(user[0]), {user: user}).should eq "T"
   end

--- a/src/lib/filter/var.cr
+++ b/src/lib/filter/var.cr
@@ -12,7 +12,7 @@ module Crinja::Filter
   Crinja::Filter::Library.alias :d, :default
 
   Crinja.filter({name: UNDEFINED}, :attr) do
-    Resolver.resolve_getattr(arguments[:name].raw, target)
+    Resolver.resolve_getattr(arguments[:name], target)
   end
 
   Crinja.filter({verbose: false}, :pprint) do

--- a/src/runtime/evaluator.cr
+++ b/src/runtime/evaluator.cr
@@ -173,7 +173,7 @@ class Crinja::Evaluator
     argument = evaluate expression.argument
 
     begin
-      value = Resolver.resolve_item(argument, object)
+      value = Resolver.resolve_attribute(argument, object)
     rescue exc : UndefinedError
       raise UndefinedError.new(name_for_expression(expression))
     end

--- a/src/runtime/py_object.cr
+++ b/src/runtime/py_object.cr
@@ -1,14 +1,13 @@
 # Include this module into your classes to make them available as values in Crinja.
 # There are three types of properties you can expose to the Crinja runtime:
 #
-# 1. `#getattr(name : Crinja::Value) : Crinja::Value`: Access an attribute (e.g. an instance property) of this class.
-# 2. `#__getitem__(name : Crinja::Value) : Crinja::Value`: Access an item (e.g. an array member) of this class.
-# 3. `#__call__(name : String) : Crinja::Callable | Callable::Proc`: Expose a callable as method of this class.
+# * `#getattr(name : Crinja::Value) : Crinja::Value`: Access an attribute (e.g. an instance property) of this class.
+# * `#__call__(name : String) : Crinja::Callable | Callable::Proc`: Expose a callable as method of this class.
 #
 # Through the static comilation it is not possible to access properties or methods of an object
 # directly from inside the Crinja runtime. These methods allow to define a name-based lookup and
 # return the corresponding values. If the looked-up name is not defined, the return value for `__call__`
-# should be `nil`. If `getattr` or `__getitem__` return `nil`, this will be a valid return value.
+# should be `nil`. If `getattr` returns `nil`, this will be a valid return value.
 #
 # They *must* return an `Undefined` if there is no attribute or item of that name. In this case,
 # `Crinja::Resolver` may try other methods of accessing the attribute or item depending on the type

--- a/src/runtime/value.cr
+++ b/src/runtime/value.cr
@@ -70,7 +70,7 @@ class Crinja
       end
       Value.new array
     when Range
-      # TODO: Implement range trough pyobject `getitem`
+      # TODO: Implement range trough pyobject `getattr`
       Value.new value.to_a
     when Iterator(Value)
       Value.new value


### PR DESCRIPTION
There was only a subtle difference between getitem and getattr (because they usually return the same values) which only becomes evident in the `attr` filter.
Crinja objects implementing `Indexable` can still provide item values through the `#[]` method that wont be resolved by `resolve_getattr`.