### PR TITLE
Fix abstract method return types

### DIFF
--- a/src/lib/operator.cr
+++ b/src/lib/operator.cr
@@ -41,7 +41,7 @@ abstract class Crinja::Operator
       true
     end
 
-    abstract def value(env : Crinja, op1 : Value, op2 : Value) : Value
+    abstract def value(env : Crinja, op1 : Value, op2 : Value)
   end
 
   module Unary
@@ -49,7 +49,7 @@ abstract class Crinja::Operator
       true
     end
 
-    abstract def value(env : Crinja, op : Value) : Value
+    abstract def value(env : Crinja, op : Value)
   end
 
   module Logic
@@ -57,7 +57,7 @@ abstract class Crinja::Operator
       true
     end
 
-    abstract def value(env : Crinja, op1 : Value, &block : -> Value) : Value
+    abstract def value(env : Crinja, op1 : Value, &block : -> Value)
   end
 end
 

--- a/src/loader.cr
+++ b/src/loader.cr
@@ -4,13 +4,13 @@ require "file_utils"
 abstract class Crinja::Loader
   # Get the template source, filename and reload helper for a template.
   # It's passed the environment and template name and has to return a
-  # tuple in the form ``{source, filename, uptodate}`` or raise a
+  # tuple in the form ``{source : String, filename : String?}`` or raise a
   # `TemplateNotFoundError` if it can't locate the template.
   # The source part of the returned tuple must be the source of the
   # template as string. The filename should be the name of the file on
   # the filesystem if it was loaded from there, otherwise `nil`.
   # The filename is used for the tracebacks if no loader extension is used.
-  abstract def get_source(env : Crinja, template : String) : {String, String}
+  abstract def get_source(env : Crinja, template : String) : {String, String?}
 
   # Iterates over all templates. If the loader does not support that
   # it should raise a `TypeError` which is the default behavior.
@@ -65,7 +65,7 @@ abstract class Crinja::Loader
       io << ")"
     end
 
-    def get_source(env : Crinja, template : String)
+    def get_source(env : Crinja, template : String) : {String, String}
       pieces = split_template_path(template)
       searchpaths.each do |searchpath|
         file_name = File.join(searchpath, File.join(pieces))
@@ -110,7 +110,7 @@ abstract class Crinja::Loader
     def initialize(@data)
     end
 
-    def get_source(env : Crinja, template : String)
+    def get_source(env : Crinja, template : String) : {String, String?}
       raise TemplateNotFoundError.new(template, self) unless data.has_key?(template)
 
       {data[template], nil}
@@ -143,7 +143,7 @@ abstract class Crinja::Loader
     def initialize(@mapping, @delimiter = "/")
     end
 
-    def get_source(env : Crinja, template : String)
+    def get_source(env : Crinja, template : String) : {String, String?}
       pos = template.index(@delimiter)
 
       if pos
@@ -179,7 +179,7 @@ abstract class Crinja::Loader
       new choices.map { |loader| loader.as(Loader) }
     end
 
-    def get_source(env : Crinja, template : String)
+    def get_source(env : Crinja, template : String) : {String, String?}
       choices.each do |loader|
         begin
           return loader.get_source(env, template)

--- a/src/runtime/callable.cr
+++ b/src/runtime/callable.cr
@@ -95,11 +95,12 @@ class Crinja
   # A Callable is a Crinja type object that can be called from an expression call. These include
   # functions, macros, tests and filters.
   # It can be implemented by an object or module which inherits from `CallableMod` or using a proc.
-  # In either way, the callable must respond to `#call(arguments : Arguments)` and return a `Value`
-  # and must be added to the environments feature library to be useable from template.
+  # In either way, the callable must respond to `#call(arguments : Arguments)` and return `Value` or
+  # a value accepted by `Crinja.value`.
+  # It must be added to the environment's feature library to be useable from template.
   # There are macros in `Crinja` which allow an easy implementation as a proc.
   module Callable
-    abstract def call(arguments : Arguments) : Value
+    abstract def call(arguments : Arguments)
 
     alias Proc = Arguments -> Value
 
@@ -113,7 +114,7 @@ class Crinja
       def initialize(@proc, @defaults = {} of String => Value, @name = nil)
       end
 
-      def call(arguments : Arguments)
+      def call(arguments : Arguments) : Crinja::Value
         @proc.call(arguments)
       end
     end

--- a/src/runtime/output.cr
+++ b/src/runtime/output.cr
@@ -4,7 +4,7 @@ class Crinja::Renderer
   end
 
   class RenderedOutput < Output
-    getter value
+    getter value : String
 
     def initialize(@value : String)
     end


### PR DESCRIPTION
This applies return types on abstract method implementations as will be required in Crystal 0.30.0 (see crystal-lang/crystal#7956).

Most return types on abstract methods are simply removed because the actual return types are too complex (`Callable#call` and `Operator#value` are pretty generic and can return anything accepted by `Crinja.value`).