### PR TITLE
Allow escaped backslashes

### DIFF
--- a/spec/parser/expression_parser_spec.cr
+++ b/spec/parser/expression_parser_spec.cr
@@ -1,12 +1,12 @@
 require "../spec_helper.cr"
 
 describe Crinja::Parser::ExpressionParser do
-  it "" do
+  it "parses string literals" do
     expression = parse_expression(%( "foo"))
     expression.should be_a(Crinja::AST::StringLiteral)
   end
 
-  it "" do
+  it "parses binary expressions" do
     expression = parse_expression(%(1 + 2))
     expression.should be_a(Crinja::AST::BinaryExpression)
     Crinja.new.evaluate(expression).should eq 3
@@ -40,5 +40,23 @@ describe Crinja::Parser::ExpressionParser do
   it "parses integer as member access" do
     expression = parse_expression("foo.1.bar")
     expression.should be_a(Crinja::AST::MemberExpression)
+  end
+
+  it "parses escaped backslashes" do
+    expression = parse_expression(%q("foo\\bar"))
+    expression.should be_a(Crinja::AST::StringLiteral)
+    expression.as(Crinja::AST::StringLiteral).value.should eq %q(foo\bar)
+  end
+
+  it "parses escaped newlines" do
+    expression = parse_expression(%q("foo\nbar"))
+    expression.should be_a(Crinja::AST::StringLiteral)
+    expression.as(Crinja::AST::StringLiteral).value.should eq "foo\nbar"
+  end
+
+  it "parses escaped quotes" do
+    expression = parse_expression(%q("\"foo\"\'bar\'"))
+    expression.should be_a(Crinja::AST::StringLiteral)
+    expression.as(Crinja::AST::StringLiteral).value.should eq %q("foo"'bar')
   end
 end

--- a/src/parser/base_lexer.cr
+++ b/src/parser/base_lexer.cr
@@ -106,6 +106,8 @@ module Crinja::Parser
             @buffer << '\n'
           when '"', '\''
             @buffer << char
+          when Symbol::STRING_ESCAPE
+            @buffer << Symbol::STRING_ESCAPE
           end
         else
           escaped = false


### PR DESCRIPTION
Escaped backslashes in string literals currently get swallowed:
```crystal
pp! Crinja.render <<-'JINJA'
  {% set foo="\\" %}{{ foo }}
  JINJA
# => ""
```