### PR TITLE
Use blocks to invoke logging

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -107,6 +107,6 @@ end
 begin
   Crinja::CLI.run
 rescue ex : OptionParser::InvalidOption
-  Crinja::CLI::Log.fatal ex.message
+  Crinja::CLI::Log.fatal { ex.message }
   exit 1
 end


### PR DESCRIPTION
Hi @straight-shoota,

When building **master**, I have a

```crystal
Showing last frame. Use --error-trace for full trace.

In src/cli.cr:110:20

 110 | Crinja::CLI::Log.fatal(exception: ex)
                        ^----
Error: 'Log#fatal' is expected to be invoked with a block, but no block was given
```

Regards,