### PR TITLE
Fix Cycler iterator return Value

### DIFF
--- a/src/lib/function/cycler.cr
+++ b/src/lib/function/cycler.cr
@@ -12,12 +12,12 @@ class Crinja::Function::Cycler
 
   @[Crinja::Attribute]
   def current
-    return "" if @index < 0 # .current called directly after initialization or rewind
-    @values[@index].raw
+    return Value::UNDEFINED if @index < 0 # .current called directly after initialization or rewind
+    @values[@index]
   end
 
   @[Crinja::Attribute]
-  def next
+  def next : Crinja::Value | ::Iterator::Stop
     @index += 1
     @index %= @values.size
     current


### PR DESCRIPTION
`Crinja::Function::Cycler#next` incorrectly returned `Value::Raw` instead of `Value` because the return type was not enforced. This caused an error in Crystal nightly: https://app.circleci.com/pipelines/github/straight-shoota/crinja/721/workflows/6cd5eb17-4e34-4e00-a2a7-441d2f4f70ad/jobs/1285
See https://github.com/crystal-lang/crystal/pull/10857#issuecomment-876284720 for details