### PR TITLE
Refactor `KeyError`, `IndexError`

### DIFF
--- a/src/parser/character_stream.cr
+++ b/src/parser/character_stream.cr
@@ -29,8 +29,6 @@ module Crinja::Parser
       else
         raise Arguments::Error.new("lookahead must be >= 0, was #{lookahead}")
       end
-    rescue IndexError
-      Char::ZERO
     end
 
     def next_char

--- a/src/runtime/resolver.cr
+++ b/src/runtime/resolver.cr
@@ -8,9 +8,8 @@ module Crinja::Resolver
 
     if value.undefined?
       if object.indexable? && name.responds_to?(:to_i)
-        begin
-          return Value.new object[name.to_i]
-        rescue IndexError
+        if v = object[name.to_i]?
+          return Value.new v
         end
       end
     end
@@ -54,9 +53,8 @@ module Crinja::Resolver
   def self.resolve_with_hash_accessor(name : Value, value : Value) : Value
     object = value.raw
     if object.responds_to?(:[]) && !object.is_a?(Array) && !object.is_a?(Crinja::Tuple) && !object.is_a?(String | SafeString)
-      begin
-        return Value.new object[name.to_s]
-      rescue KeyError
+      if value = object[name.to_s]?
+        return Value.new value
       end
     end
 


### PR DESCRIPTION
Refactor rescuing `KeyError` and `IndexError` to use nilable index accessor instead.

This is a breaking change for `resolve_with_hash_accessor` if the backing implementation only respond to `#[]` and not `#[]?`. But per documenation, backing implementations are expected to expose a hash-like interface, which includes `#[]?`.

/cc https://github.com/crystal-lang/crystal/issues/11565#issuecomment-1003040007