### PR TITLE
Fix crystal tool format for Crystal 1.6.0-dev

### DIFF
--- a/src/lib/feature_library.cr
+++ b/src/lib/feature_library.cr
@@ -41,6 +41,7 @@ abstract class Crinja::FeatureLibrary(T)
     class_getter defaults = [] of T
 
     @@aliases = {} of String => String
+
     def self.alias(from, to)
       @@aliases[from.to_s] = to.to_s
     end


### PR DESCRIPTION
Applies formatter for macro bodies, introduced in https://github.com/crystal-lang/crystal/pull/12378