### PR TITLE
Make `RawIterator` generic

### DIFF
--- a/spec/interpreter/value_spec.cr
+++ b/spec/interpreter/value_spec.cr
@@ -48,7 +48,9 @@ describe Crinja::Value do
     end
 
     it "raw_#each" do
-      Crinja::Value.new([1]).raw_each.should be_a(Crinja::Value::RawIterator)
+      # be_a matcher doesn't support uninstantiated generic type
+      Crinja::Value.new([1]).raw_each.is_a?(Crinja::Value::RawIterator).should be_true
+
       Crinja::Value.new([1]).raw_each.each_with_index do |item, index|
         item.should eq 1
         index.should eq 0

--- a/src/runtime/value.cr
+++ b/src/runtime/value.cr
@@ -260,11 +260,11 @@ struct Crinja::Value
   end
 
   # :nodoc:
-  class RawIterator
+  class RawIterator(T)
     include ::Iterator(Raw)
     include IteratorWrapper
 
-    def initialize(@iterator : ::Iterator(Value))
+    def initialize(@iterator : T)
     end
 
     def next


### PR DESCRIPTION
This is a workaround for a Crystal compiler bug (https://github.com/crystal-lang/crystal/issues/14317).
But it might also be benefitial on its own (https://github.com/straight-shoota/crinja/issues/70#issuecomment-1962868432) so I'm not leaving a note to eventually revert this.

`RawIterator` is an undocumented internal type, so this change should be fine with regards to backwards compatibility.

Resolves #70