### PR TITLE
cli: remove use of deprecated OptionParser.parse! method

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -44,7 +44,7 @@ module Crinja::CLI
   end
 
   def self.run
-    OptionParser.parse! do |opts|
+    OptionParser.parse do |opts|
       library_defaults = false
       only_names = false
 


### PR DESCRIPTION
As per https://github.com/crystal-lang/crystal/pull/10386 / https://github.com/crystal-lang/crystal/commit/bd1d44c2e82ad11aae0826fe0853d2a645cd9f4f#diff-9ed75ec853be66b1a047c7de0065816267b533de9567afa1bc22651dd9ecb089L119 , the `parse!` method is deprecated and was finally removed from Crystal at some point. Building the CLI on modern crystal fails as a consequence:

```
> crystal --version
Crystal 1.16.3 (2025-06-04)

LLVM: 20.1.8
Default target: x86_64-pc-linux-gnu
> shards --version
Shards 0.19.1 (2025-01-26)
> shards build --error-trace
Dependencies are satisfied
Building: crinja
Error target crinja failed to compile:
In src/cli.cr:108:15

 108 | Crinja::CLI.run
                   ^--
Error: instantiating 'Crinja::CLI.run()'


In src/cli.cr:47:18

 47 | OptionParser.parse! do |opts|
                   ^-----
Error: undefined method 'parse!' for OptionParser.class

OptionParser.class trace:

  src/cli.cr:47

        OptionParser.parse! do |opts|

```

Given the `.parse` method still defaults to handling `ARGV` (see https://github.com/crystal-lang/crystal/blob/1.16.3/src/option_parser.cr#L361) it seems nothing else needs to change here.
