### PR TITLE
cli: update exception logging syntax

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -107,6 +107,6 @@ end
 begin
   Crinja::CLI.run
 rescue ex : OptionParser::InvalidOption
-  Crinja::CLI::Log.fatal ex.message
+  Crinja::CLI::Log.fatal(exception: ex) { ex.message }
   exit 1
 end


### PR DESCRIPTION
Similar to #85, the current logger call in the CLI exception handling doesn't compile on current Crystal - I assume the syntax was changed at some point:

```
> crystal --version
Crystal 1.16.3 (2025-06-04)

LLVM: 20.1.8
Default target: x86_64-pc-linux-gnu
> shards --version
Shards 0.19.1 (2025-01-26)
> shards build --error-trace
Dependencies are satisfied
Building: crinja
Error target crinja failed to compile:
In src/cli.cr:110:20

 110 | Crinja::CLI::Log.fatal ex.message
                        ^----
Error: wrong number of arguments for 'Log#fatal' (given 1, expected 0)

Overloads are:
 - Log#fatal(*, exception : Exception)
 - Log#fatal(*, exception : Exception | ::Nil = nil, &)
```

As per https://crystal-lang.org/api/1.17.1/Log.html , apparently the log methods "expect a block that will evaluate to the message of the entry".

---

Funnily enough, I don't think this exception handler ever ends up being callable anyway, because the invalid_option exception raising comes in a `invalid_option` call point that happens after `unknown_args` handling: https://github.com/crystal-lang/crystal/blob/1.16.3/src/option_parser.cr#L496 . Looking at the unknown args handler in this project, `exit` is called in every flow case, so the program will never execute to the point of the invalid option handler being called.
https://github.com/straight-shoota/crinja/blob/db7eb9ea2f2d8a5601cfcea672f7670f8d01e8f1/src/cli.cr#L78-L102