### PR TITLE
Add Proc check in resolve_with_hash_accessor method

### DIFF
--- a/src/runtime/resolver.cr
+++ b/src/runtime/resolver.cr
@@ -52,7 +52,7 @@ module Crinja::Resolver
 
   def self.resolve_with_hash_accessor(name : Value, value : Value) : Value
     object = value.raw
-    if object.responds_to?(:[]?) && !object.is_a?(Array) && !object.is_a?(Crinja::Tuple) && !object.is_a?(String | SafeString)
+    if object.responds_to?(:[]?) && !object.is_a?(Array) && !object.is_a?(Crinja::Tuple) && !object.is_a?(String | SafeString) && !object.is_a?(Proc)
       if value = object[name.to_s]?
         return Value.new value
       end


### PR DESCRIPTION
https://github.com/straight-shoota/crinja/issues/93

fixes:

```
❯ crystal spec
In src/runtime/resolver.cr:58:32

 58 | return Value.new object[name.to_s]
                             ^
Error: no overload matches 'Proc(Crinja::Arguments, Crinja::Value)#[]' with type String

Overloads are:
 - Proc(*T, R)#[](*args : *T)
 ```