### PR TITLE
Increase minimum supported Crystal version 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         - os: ubuntu-latest
           crystal: latest
         - os: ubuntu-latest
-          crystal: 1.0.0
+          crystal: 1.13
         - os: ubuntu-latest
           crystal: nightly
         - os: macos-latest
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        crystal: [1.0.0, latest, nightly]
+        crystal: [1.13, latest, nightly]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: crinja
 version: 0.8.1
 license: Apache-2.0
-crystal: '>= 0.35.0'
+crystal: '>= 1.13.0'
 
 authors:
   - Johannes Müller <straightshoota@gmail.com>


### PR DESCRIPTION
Deprecation replacements in #80 require at least Crystal 1.13.