### PR TITLE
Fix `resolve()` to prioritize context variables over global functions

### DIFF
--- a/spec/tags/for_spec.cr
+++ b/spec/tags/for_spec.cr
@@ -195,4 +195,17 @@ describe Crinja::Tag::For do
     render(%({% for item in seq %}{{ x }}{% set x = item %}{{ x }}{% endfor %}), bindings).should eq "010203"
     render(%({% set x = 9 %}{% for item in seq %}{{ x }}{% set x = item %}{{ x }}{% endfor %}), bindings).should eq "919293"
   end
+
+  it "loop variable shadows global function of the same name" do
+    env = Crinja.new
+    env.functions["foo"] = Crinja.function do
+      Crinja::Value.new("function_result")
+    end
+
+    template = env.from_string(%({% for item in seq %}{{ item }}{% endfor %}))
+    template.render({"seq" => ["a", "b"]}).should eq "ab"
+    
+    template = env.from_string(%({% for entry in seq %}{{ item }}{% endfor %}))
+    template.render({"seq" => ["a", "b"]}).should eq "calledcalled"
+  end
 end

--- a/spec/tags/for_spec.cr
+++ b/spec/tags/for_spec.cr
@@ -199,13 +199,13 @@ describe Crinja::Tag::For do
   it "loop variable shadows global function of the same name" do
     env = Crinja.new
     env.functions["foo"] = Crinja.function do
-      Crinja::Value.new("function_result")
+      Crinja::Value.new("called")
     end
 
-    template = env.from_string(%({% for item in seq %}{{ item }}{% endfor %}))
+    template = env.from_string(%({% for foo in seq %}{{ foo }}{% endfor %}))
     template.render({"seq" => ["a", "b"]}).should eq "ab"
-    
-    template = env.from_string(%({% for entry in seq %}{{ item }}{% endfor %}))
+
+    template = env.from_string(%({% for entry in seq %}{{ foo() }}{% endfor %}))
     template.render({"seq" => ["a", "b"]}).should eq "calledcalled"
   end
 end

--- a/spec/tags/set_spec.cr
+++ b/spec/tags/set_spec.cr
@@ -24,4 +24,15 @@ describe Crinja::Tag::Set do
       render(%({% set foo %}{{ foo }}))
     end
   end
+
+  it "set variable shadows global function of the same name" do
+    env = Crinja.new
+    env.functions["foo"] = Crinja.function do
+      Crinja::Value.new("function_result")
+    end
+
+    template = env.from_string(%({% set foo = "bar" %}{{ foo }}))
+    result = template.render(env)
+    result.should eq "bar"
+  end
 end

--- a/src/runtime/resolver.cr
+++ b/src/runtime/resolver.cr
@@ -89,11 +89,15 @@ module Crinja::Resolver
   end
 
   # Resolves a variable in the current context.
+  # Context (scope) variables take priority over global functions,
+  # matching Jinja2 semantics where loop variables and `set` assignments
+  # shadow same-named global functions.
   def resolve(name : String) : Value
-    if functions.has_key?(name)
+    value = context[name]
+    if value.undefined? && functions.has_key?(name)
       Value.new functions[name]
     else
-      context[name]
+      value
     end
   end
 


### PR DESCRIPTION
Hi @straight-shoota! Thanks for the quick response on #101. 
Here's a PR based on your suggested approach.

## Summary
`resolve()` now checks context (scope) variables before the global function registry, matching Jinja2 semantics. Previously, a registered global function would always shadow a same-named loop variable or `set` assignment:

```crystal
env.functions["asset"] = Crinja.function({name: ""}) { ... }

{% for asset in items %}
  {{ asset }}  {# rendered as *unnamed_callable_*  instead of the actual value #}
{% endfor %}
```

## Changes

- src/runtime/resolver.cr: Flip priority in resolve(): check context[name] first, fall back to functions[name] only when undefined
- spec/tags/for_spec.cr: Add tests for loop variable shadowing a global function
- spec/tags/set_spec.cr: Add test for set variable shadowing a global function

## Test

Code
```crystal
require "./src/crinja"

env = Crinja.new

env.functions["asset"] = Crinja.function({name: ""}) do
  Crinja::Value.new("resolved-asset")
end

template = env.from_string(<<-TMPL)
{% for asset in items -%}
  {{ asset }}
{% endfor -%}
TMPL

vars = {
  "items" => Crinja::Value.new(["alpha.jpg", "beta.png"]),
}

puts template.render(vars)
```

Run
```bash
crystal run test.cr
  alpha.jpg
  beta.png
```

Let me know if there's anything you'd like me to adjust!