### PR TITLE
Memoize feature name resolution and autoescape decisions

### DIFF
--- a/src/config.cr
+++ b/src/config.cr
@@ -93,24 +93,36 @@ class Crinja::Config
 
     def enabled_extensions=(extensions : Array(String))
       @enabled_extensions = extensions.map(&.downcase)
+      @autoescape_cache.clear
     end
 
     def disabled_extensions=(extensions : Array(String))
       @disabled_extensions = extensions.map(&.downcase)
+      @autoescape_cache.clear
     end
 
     # Determines if a template with *filename* should have autoescape enabled or not.
     def autoescape?(filename : String? = nil)
       if filename.nil? || filename.size == 0
         default_for_string
-      elsif self.class.match_extension?(enabled_extensions, filename)
-        true
-      elsif self.class.match_extension?(disabled_extensions, filename)
-        false
       else
-        default
+        # Memoize per filename: this is evaluated for every render.
+        @autoescape_cache.fetch(filename) do
+          result =
+            if self.class.match_extension?(enabled_extensions, filename)
+              true
+            elsif self.class.match_extension?(disabled_extensions, filename)
+              false
+            else
+              default
+            end
+          @autoescape_cache[filename] = result
+          result
+        end
       end
     end
+
+    @autoescape_cache = {} of String => Bool
 
     # :nodoc:
     def self.match_extension?(extensions : Array(String), filename : String)

--- a/src/lib/feature_library.cr
+++ b/src/lib/feature_library.cr
@@ -20,6 +20,9 @@ abstract class Crinja::FeatureLibrary(T)
     # FIXME: Move ivar initialization to property definition
     @store = {} of String => T
     @aliases = {} of String => String
+    # Memoizes resolved lookups (original name => feature) so that repeated
+    # accesses from a parsed AST don't need downcasing and alias resolution.
+    @lookup_cache = {} of String => T
 
     self.register_defaults if register_defaults
   end
@@ -93,18 +96,24 @@ abstract class Crinja::FeatureLibrary(T)
   #
   # If the lookup name is in the list of `#disabled` features, a `SecurityError` is raised.
   # If the lookup name is not registered, an `UnknownFeatureError` is raised.
-  def [](lookup) : T
-    lookup = lookup.to_s.downcase
-    lookup = @aliases.fetch(lookup, lookup)
+  def [](lookup : String) : T
+    if (cached = @lookup_cache[lookup]?)
+      return cached
+    end
 
-    feature = @store[lookup]?
+    key = lookup.downcase
+    key = @aliases.fetch(key, key)
 
-    if disabled.includes?(lookup)
-      feature_name = feature.try(&.to_s) || lookup
+    feature = @store[key]?
+
+    if disabled.includes?(key)
+      feature_name = feature.try(&.to_s) || key
       raise SecurityError.new("access to #{name} `#{feature_name}` is disabled.")
     end
 
-    raise UnknownFeatureError.new(self.name, lookup) if feature.nil?
+    raise UnknownFeatureError.new(self.name, key) if feature.nil?
+
+    @lookup_cache[lookup] = feature
 
     feature
   end
@@ -112,6 +121,7 @@ abstract class Crinja::FeatureLibrary(T)
   # Stores a feature object *obj* under the key *name*.
   def []=(name, obj : T)
     @store[name.to_s.downcase] = obj
+    @lookup_cache.clear
   end
 
   # Stores a feature object *obj* under the key *name*.

--- a/src/lib/feature_library.cr
+++ b/src/lib/feature_library.cr
@@ -97,7 +97,7 @@ abstract class Crinja::FeatureLibrary(T)
   # If the lookup name is in the list of `#disabled` features, a `SecurityError` is raised.
   # If the lookup name is not registered, an `UnknownFeatureError` is raised.
   def [](lookup : String) : T
-    if (cached = @lookup_cache[lookup]?)
+    if cached = @lookup_cache[lookup]?
       return cached
     end
 


### PR DESCRIPTION
## Summary

This PR memoizes two lookups that were re-computed on every operation during template rendering:

1. **Feature library resolution** (`FeatureLibrary#[]`): every `|filter`, `is test`, operator, and function call from a parsed AST downcased its name, resolved aliases, and performed hash lookups. Successful lookups are now cached keyed by the original name. The cache is invalidated whenever features are (re-)registered via `#[]=`, so dynamic registration keeps working.

2. **Autoescape decision** (`Config::Autoescape#autoescape?`): the template filename was downcased and matched against extension lists on *every render*. The result is now memoized per filename; the cache is invalidated when `enabled_extensions`/`disabled_extensions` change.

No behavior changes: disabled features still raise `SecurityError` on every access (they are not cached), unknown features still raise `UnknownFeatureError`.

## Benchmark

Benchmarking [Nicolino](https://github.com/ralsina/nicolino) against this fork shows a measurable improvement in template rendering performance over upstream. Using Nicolino's `-v4` instrumentation on a vendored 4000-page markdown corpus (`bench/site-nicolino`), the crinja-bound template task dropped from ~1240ms to ~1113ms for 4001 rendered pages — **a 10% reduction in engine time**, roughly 32µs saved per page render.

The improvement is specific to the rendering path: discount markdown compilation (350ms), relativization (~57ms), and task registration are unaffected, confirming the changes optimize crinja's execution rather than anything upstream of it.

Workload characteristics matter for interpreting these numbers: this is a template-heavy but template-poor workload — 18 templates loaded once at startup and reused across thousands of pages, so nearly all crinja time goes to repeated rendering rather than parsing or compilation. The gain therefore comes from the render/execution path, not template loading. Rendering accounts for roughly half of total build time in this configuration, so the 10% engine-level improvement translates to about a 7% end-to-end build speedup; workloads with more complex templates or a higher rendering-to-markdown ratio would see proportionally larger absolute benefits.